### PR TITLE
Added Rival Wings Calculations + Frontline Daily Bonus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # FFXIV PVP Malmstone XP Calculator
-Quick calculator utility for checking how many PvP matches you'll need to play to get between series malmstones in FFXIV's PvP seasons. Up to date as of Patch 6.3, and should continue to be accurate unless they change rank requirements in a future patch.
+Quick calculator utility for checking how many PvP matches you'll need to play to get between series malmstones in FFXIV's PvP seasons. Up to date as of Patch 7.2, and should continue to be accurate unless they change rank requirements in a future patch.

--- a/index.html
+++ b/index.html
@@ -39,6 +39,13 @@
 				<button type="button" class="btn btn-primary" id="addFlMid">+FL 2nd</button>
 				<button type="button" class="btn btn-primary" id="addFlLoss">+FL 3rd</button>
 			</div>
+			<div class="col-md-6 text-center">
+				<button type="button" class="btn btn-primary" id="addRwWin">+RW Win</button>
+				<button type="button" class="btn btn-primary" id="addRwLoss">+RW Loss</button>
+			</div>
+			<div class="col-md-6 text-center">
+				<button type="button" class="btn btn-primary" id="addFlDaily">+FL Roulette Bonus</button>
+			</div>
 		</form>
 		<hr/>
 		<fieldset disabled>
@@ -47,21 +54,29 @@
 					<label for="resultXp" class="form-label">XP Required</label>
 					<input type="number" class="form-control" id="resultXp" placeholder="Not Calculated">
 				</div>
-				<div class="col-md-6">
+				<div class="col-md-4">
 					<label for="resultCcWin" class="form-label">Crystalline Conflict Wins</label>
 					<input type="number" class="form-control" id="resultCcWin" placeholder="Not Calculated">
 				</div>
-				<div class="col-md-6">
+				<div class="col-md-4">
 					<label for="resultFlWin" class="form-label">Frontline Wins</label>
 					<input type="number" class="form-control" id="resultFlWin" placeholder="Not Calculated">
 				</div>
-				<div class="col-md-6">
+				<div class="col-md-4">
+					<label for="resultRwWin" class="form-label">Rival Wings Wins</label>
+					<input type="number" class="form-control" id="resultRwWin" placeholder="Not Calculated">
+				</div>
+				<div class="col-md-4">
 					<label for="resultCcLoss" class="form-label">Crystalline Conflict Losses</label>
 					<input type="number" class="form-control" id="resultCcLoss" placeholder="Not Calculated">
 				</div>
-				<div class="col-md-6">
+				<div class="col-md-4">
 					<label for="resultFlLoss" class="form-label">Frontline Losses *</label>
 					<input type="number" class="form-control" id="resultFlLoss" placeholder="Not Calculated">
+				</div>
+				<div class="col-md-4">
+					<label for="resultRwLoss" class="form-label">Rival Wings Losses</label>
+					<input type="number" class="form-control" id="resultRwLoss" placeholder="Not Calculated">
 				</div>
 				<small><div class="d-flex justify-content-center">* Frontline calculations do not take into account percentage bonuses for consecutive losses. In reality, the min-max amount of frontlines required will always be weighted slightly more towards the minimum as losing multiple in a row gives stacking reward bonuses in future matches.</div></small>
 			</form>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,9 @@ const CC_LOSS = 700;
 const FL_WIN = 1500;
 const FL_MID = 1250;
 const FL_LOSS = 1000;
+const FL_DAILY = 1500;
+const RW_WIN = 1250;
+const RW_LOSS = 750;
 const RANKS = [
 	0,    // 0-1
 	2000, // 1-2
@@ -77,6 +80,8 @@ function calcResults() {
 	$('#resultCcLoss').val(Math.ceil(xp / CC_LOSS));
 	$('#resultFlWin').val(Math.ceil(xp / FL_WIN));
 	$('#resultFlLoss').val(Math.ceil(xp / FL_LOSS));
+	$('#resultRwWin').val(Math.ceil(xp / RW_WIN));
+	$('#resultRwLoss').val(Math.ceil(xp / RW_LOSS));
 }
 
 function addXp(amount) {
@@ -131,6 +136,9 @@ $('#addCcLoss').on('click', () => addXp(CC_LOSS));
 $('#addFlWin').on('click', () => addXp(FL_WIN));
 $('#addFlMid').on('click', () => addXp(FL_MID));
 $('#addFlLoss').on('click', () => addXp(FL_LOSS));
+$('#addFlDaily').on('click', () => addXp(FL_DAILY));
+$('#addRwWin').on('click', () => addXp(RW_WIN));
+$('#addRwLoss').on('click', () => addXp(RW_LOSS));
 
 let inputRank = localStorage.getItem("inputRank");
 if (inputRank !== null) $('#inputRank').val(inputRank);


### PR DESCRIPTION
Added quick win/loss buttons and target match amount calculations for Rival Wings XP. Additionally added a quick button for Frontline Daily Roulette bonus XP.

Closes #1 